### PR TITLE
Add support for new media queries features

### DIFF
--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -625,7 +625,7 @@ contexts:
                     ((device-)?(height|width|aspect-ratio|pixel-ratio))|
                     (color(-index)?)|monochrome|resolution
                 )
-            )|grid|scan|orientation
+            )|grid|scan|orientation|pointer|hover|any-pointer|any-hover|prefers-color-scheme|prefers-reduced-motion
             \s*(?=[:)])
           captures:
             0: support.type.property-name.media.css
@@ -636,7 +636,7 @@ contexts:
               captures:
                 1: punctuation.separator.key-value.css
               pop: true
-        - match: \b(portrait|landscape|progressive|interlace)
+        - match: \b(portrait|landscape|progressive|interlace|light|dark|reduce|no-preference|fine|coarse|hover|none)
           scope: support.constant.property-value.css
         - match: \s*(\d+)(/)(\d+)
           captures:

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1077,14 +1077,14 @@ contexts:
                   |color(?:-index)?|monochrome|resolution
                 )
               )
-              |grid|scan|orientation
+              |grid|scan|orientation|pointer|hover|any-pointer|any-hover|prefers-color-scheme|prefers-reduced-motion
             )\s*(:)?
           captures:
             1: support.type.property-name.media.css
             2: support.type.vendor-prefix.css
             3: support.type.vendor-prefix.css
             4: punctuation.separator.key-value.css
-        - match: \b(portrait|landscape|progressive|interlace)
+        - match: \b(portrait|landscape|progressive|interlace|light|dark|reduce|no-preference|fine|coarse|hover|none)
           scope: support.constant.property-value.css
         - match: '\s*(\d+)(/)(\d+)'
           captures:


### PR DESCRIPTION
This PR adds support for new media queries features:

* [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
* [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
* [`any-pointer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/any-pointer) and [`pointer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer)
* [`any-hover`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/any-hover) and [`hover`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover)